### PR TITLE
feat(music): 實現遊戲化 DJ 主控權與閒置重置機制

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -575,3 +575,87 @@ mark {
   96% { height: 40%; }
   100% { height: 30%; }
 }
+
+/* ✨ 透明化升級：TTL 重置動畫 */
+@keyframes ttl-reset-bounce {
+  0% {
+    transform: translateY(20px) scale(0.8);
+    opacity: 0;
+  }
+  30% {
+    transform: translateY(-8px) scale(1.1);
+    opacity: 1;
+  }
+  60% {
+    transform: translateY(3px) scale(0.95);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ttl-reset-glow {
+  0%, 100% {
+    box-shadow: 0 0 5px rgba(16, 185, 129, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(16, 185, 129, 0.8), 0 0 30px rgba(16, 185, 129, 0.4);
+  }
+}
+
+.ttl-reset-animation {
+  animation: ttl-reset-bounce 0.6s ease-out, ttl-reset-glow 1.5s ease-in-out;
+}
+
+/* ✨ DJ 轉換動畫 */
+@keyframes dj-transition-slide {
+  0% {
+    transform: translateY(-20px) scale(0.9);
+    opacity: 0;
+  }
+  20% {
+    transform: translateY(0) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+.dj-transition-animation {
+  animation: dj-transition-slide 0.8s ease-out;
+}
+
+/* ✨ Crown 閃爍效果增強 */
+.crown-glow {
+  filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.6));
+  animation: crown-pulse 2s ease-in-out infinite;
+}
+
+@keyframes crown-pulse {
+  0%, 100% {
+    filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.6));
+  }
+  50% {
+    filter: drop-shadow(0 0 15px rgba(251, 191, 36, 0.9));
+  }
+}
+
+/* ✨ 透明化升級：DJ 統計信息動畫 */
+@keyframes stats-fade-in {
+  0% {
+    opacity: 0;
+    transform: translateX(10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.dj-stats-animation {
+  animation: stats-fade-in 0.5s ease-out;
+}

--- a/src/components/FloatingAnthemButton.tsx
+++ b/src/components/FloatingAnthemButton.tsx
@@ -37,8 +37,8 @@ export default function FloatingAnthemButton() {
 
   return (
     <>
-      {/* 懸浮徽章 - 移到左側與AI按鈕對齊 */}
-      <div className="fixed z-50 bottom-8 left-8">
+      {/* 懸浮徽章 - 響應式位置：手機左側，非手機在AI按鈕上方 */}
+      <div className="fixed z-50 bottom-8 left-8 sm:bottom-32 sm:right-8 sm:left-auto">
         {/* 背景光暈效果 */}
         {!isAboutPage && (
           <div 
@@ -85,14 +85,14 @@ export default function FloatingAnthemButton() {
         </button>
       </div>
 
-      {/* Popover 卡片 - 調整位置適應左側 */}
+      {/* Popover 卡片 - 響應式位置：手機左側，非手機右側 */}
       {open && (
         <div
           ref={popoverRef}
-          className="fixed z-50 bottom-28 left-8"
+          className="fixed z-50 bottom-28 left-8 sm:bottom-52 sm:right-8 sm:left-auto"
         >
-          {/* 箭頭 - 調整方向適應左側 */}
-          <div className="flex justify-start pl-6 mb-1">
+          {/* 箭頭 - 響應式方向 */}
+          <div className="flex justify-start pl-6 mb-1 sm:justify-end sm:pr-6 sm:pl-0">
             <div className="relative">
               <div className="w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-white/80 dark:border-t-slate-800/80 backdrop-blur-sm" />
               <div className="absolute bottom-0 left-0 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-sky-500/20" />

--- a/src/components/ProTipToast.tsx
+++ b/src/components/ProTipToast.tsx
@@ -37,7 +37,7 @@ export function ProTipToast() {
 
     const timer = setTimeout(() => {
       const desktopMessage = '<strong>Pro Tip:</strong> 按下 <strong>⌘+K</strong>，搜尋文章或執行指令！';
-      const mobileMessage = '<strong>Pro Tip:</strong> 點擊頂部「搜尋」圖示，探索更多隱藏功能！';
+      const mobileMessage = '<strong>提示:</strong> 點擊頂部搜尋圖示，探索功能！';
       
       const message = isDesktop ? desktopMessage : mobileMessage;
 

--- a/src/components/SpotifyProvider.tsx
+++ b/src/components/SpotifyProvider.tsx
@@ -45,12 +45,13 @@ export const SpotifyProvider = ({ children }: { children: ReactNode }) => {
     isControllable, 
     expirationText,
     claimMasterDevice,
-    checkPermissions 
+    checkPermissions,
+    createIdleResetAction 
   } = useMasterDevice({ 
     deviceId 
   });
 
-  // Playback Control
+  // ✨ Playback Control with Idle Reset
   const {
     playTrack,
     handlePlay,
@@ -68,6 +69,7 @@ export const SpotifyProvider = ({ children }: { children: ReactNode }) => {
     defaultPlaylistId: DEFAULT_PLAYLIST_ID,
     hasPermissions: checkPermissions,
     claimMasterDevice,
+    createIdleResetAction,
   });
 
   // Context value

--- a/src/hooks/useMasterDevice.ts
+++ b/src/hooks/useMasterDevice.ts
@@ -14,6 +14,10 @@ interface UseMasterDeviceReturn {
   claimMasterDevice: () => Promise<boolean>;
   checkPermissions: () => Promise<boolean>;
   updateMasterDeviceStatus: () => Promise<void>;
+  createIdleResetAction: <T extends any[]>(
+    action: (...args: T) => Promise<void>,
+    actionName?: string
+  ) => (...args: T) => Promise<void>;
 }
 
 export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDeviceReturn {
@@ -142,6 +146,18 @@ export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDe
     }
   }, [deviceId, masterDeviceId, setMasterInfo, setCountdown]);
 
+  // ✨ 方案 B：閒置重置制功能
+  const createIdleResetAction = useCallback(<T extends any[]>(
+    action: (...args: T) => Promise<void>,
+    actionName?: string
+  ) => {
+    return masterDeviceService.current.createIdleResetAction(
+      action,
+      deviceId,
+      actionName || 'User Action'
+    );
+  }, [deviceId]);
+
   return {
     masterDeviceId,
     isControllable,
@@ -149,5 +165,6 @@ export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDe
     claimMasterDevice,
     checkPermissions,
     updateMasterDeviceStatus,
+    createIdleResetAction,
   };
 } 

--- a/src/hooks/useMasterDevice.ts
+++ b/src/hooks/useMasterDevice.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useMusicStore } from '@/store/music';
 import { MasterDeviceService } from '@/lib/spotify/masterDeviceService';
 import { useCountdownTimer } from './useCountdownTimer';
+import { DJStatus, TTLResetEvent } from '@/types/spotify';
 
 interface UseMasterDeviceProps {
   deviceId: string | null;
@@ -18,13 +19,26 @@ interface UseMasterDeviceReturn {
     action: (...args: T) => Promise<void>,
     actionName?: string
   ) => (...args: T) => Promise<void>;
+  currentDJ: DJStatus | null;
+  djName: string | null;
 }
 
 export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDeviceReturn {
-  const { setMasterInfo, setCountdown, countdown } = useMusicStore();
+  const { 
+    setMasterInfo, 
+    setCountdown, 
+    countdown,
+    setDJStatus,
+    triggerTTLResetAnimation,
+    triggerDJTransition,
+    djStatus
+  } = useMusicStore();
   
   const [masterDeviceId, setMasterDeviceId] = useState<string | null>(null);
   const [expirationText, setExpirationText] = useState<string>('5 分鐘');
+  
+  // ✨ 透明化升級：追蹤上次操作時間，用於檢測 TTL 重置
+  const lastActionTimeRef = useRef<number | null>(null);
   
   // 使用 service 實例來處理業務邏輯
   const masterDeviceService = useRef(new MasterDeviceService());
@@ -38,63 +52,143 @@ export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDe
   // 檢查當前設備是否可控制
   const isControllable = !masterDeviceId || masterDeviceId === deviceId;
 
-  // 初始化主控裝置配置和狀態
+  // ✨ 透明化升級：檢測 DJ 狀態變化並觸發動畫
+  const detectDJStatusChanges = useCallback((newDJStatus: DJStatus | null, oldDJStatus: DJStatus | null) => {
+    // 檢測 TTL 重置（操作時間戳變化）
+    if (newDJStatus && oldDJStatus && newDJStatus.lastActionAt > oldDJStatus.lastActionAt) {
+      const resetEvent: TTLResetEvent = {
+        newTTL: 120, // 2 分鐘
+        resetBy: newDJStatus.ownerName,
+        actionType: newDJStatus.lastAction?.type || 'UNKNOWN',
+        timestamp: newDJStatus.lastActionAt
+      };
+      
+      console.log('🎯 檢測到 TTL 重置:', resetEvent);
+      triggerTTLResetAnimation(resetEvent);
+      
+      // 3 秒後清除動畫
+      setTimeout(() => {
+        useMusicStore.getState().clearTTLResetAnimation();
+      }, 3000);
+    }
+    
+    // 檢測 DJ 轉換
+    if (!oldDJStatus && newDJStatus) {
+      // 新 DJ 上線
+      triggerDJTransition('CLAIMED', newDJStatus.ownerName);
+      setTimeout(() => {
+        useMusicStore.getState().clearDJTransition();
+      }, 4000);
+    } else if (oldDJStatus && !newDJStatus) {
+      // DJ 下線
+      triggerDJTransition('RELEASED', oldDJStatus.ownerName);
+      setTimeout(() => {
+        useMusicStore.getState().clearDJTransition();
+      }, 4000);
+    } else if (oldDJStatus && newDJStatus && oldDJStatus.deviceId !== newDJStatus.deviceId) {
+      // DJ 更換
+      triggerDJTransition('EXPIRED', oldDJStatus.ownerName);
+      setTimeout(() => {
+        triggerDJTransition('CLAIMED', newDJStatus.ownerName);
+        setTimeout(() => {
+          useMusicStore.getState().clearDJTransition();
+        }, 4000);
+      }, 2000);
+    }
+  }, [triggerTTLResetAnimation, triggerDJTransition]);
+
+  // ✨ 透明化升級：初始化 DJ 狀態管理
   useEffect(() => {
-    const initializeMasterDevice = async () => {
+    const initializeDJStatus = async () => {
       if (!deviceId) return;
 
       try {
-        const result = await masterDeviceService.current.initializeMasterDevice(deviceId);
+        // 直接調用透明化 API 獲取完整的 DJ 狀態
+        const response = await fetch(`/api/spotify/master-device?deviceId=${deviceId}`);
+        const result = await response.json();
         
-        setMasterDeviceId(result.masterDeviceId);
-        setExpirationText(result.expirationText);
-        setMasterInfo(result.state);
-        setCountdown(result.state.ttl);
-        
-        // 智能重新聲明邏輯
-        if (result.shouldAttemptReclaim) {
-          console.log('Attempting to reclaim master device after page refresh (session-based)...');
-          setTimeout(async () => {
-            const success = await masterDeviceService.current.autoReclaimMasterDevice(deviceId);
-            if (!success) {
-              console.warn('Auto reclaim failed');
-            }
-          }, 2000); // 等待 2 秒讓播放器準備就緒
+        if (result.djStatus) {
+          setMasterDeviceId(result.djStatus.deviceId);
+          setDJStatus(result.djStatus);
+          
+          // 檢測狀態變化
+          detectDJStatusChanges(result.djStatus, djStatus);
+        } else {
+          setMasterDeviceId(null);
+          setDJStatus(null);
         }
+        
+        setMasterInfo({
+          isMaster: result.isMaster || false,
+          isLocked: result.isLocked || false,
+          ttl: result.ttl || 0
+        });
+        setCountdown(result.ttl || 0);
+        
+        // 獲取配置信息
+        try {
+          const configResponse = await fetch('/api/spotify/master-device/config');
+          const config = await configResponse.json();
+          setExpirationText(config.expirationText || '2 分鐘');
+        } catch (configError) {
+          console.warn('Failed to load config:', configError);
+          setExpirationText('2 分鐘');
+        }
+        
       } catch (error) {
-        console.error('Failed to initialize master device:', error);
-        masterDeviceService.current.handleError(error);
+        console.error('Failed to initialize DJ status:', error);
+        // Fallback values
+        setMasterDeviceId(null);
+        setDJStatus(null);
+        setMasterInfo({ isMaster: false, isLocked: false, ttl: 0 });
+        setCountdown(0);
       }
     };
 
-    initializeMasterDevice();
-  }, [deviceId, setMasterInfo, setCountdown]);
+    initializeDJStatus();
+  }, [deviceId, setMasterInfo, setCountdown, setDJStatus]);
 
-  // 更新主控裝置狀態
+  // ✨ 透明化升級：更新 DJ 狀態
   const updateMasterDeviceStatus = useCallback(async () => {
+    if (!deviceId) return;
+    
     try {
-      const result = await masterDeviceService.current.updateMasterDeviceStatus(
-        masterDeviceId,
-        deviceId
-      );
+      const response = await fetch(`/api/spotify/master-device?deviceId=${deviceId}`);
+      const result = await response.json();
       
-      setMasterDeviceId(result.masterDeviceId);
-      setMasterInfo(result.state);
-      setCountdown(result.state.ttl);
+      const oldDJStatus = djStatus;
       
-      // 如果需要清除記錄
-      if (result.shouldClearRecords) {
-        masterDeviceService.current.clearSessionRecords();
+      if (result.djStatus) {
+        setMasterDeviceId(result.djStatus.deviceId);
+        setDJStatus(result.djStatus);
+        
+        // 檢測狀態變化
+        detectDJStatusChanges(result.djStatus, oldDJStatus);
+      } else {
+        setMasterDeviceId(null);
+        setDJStatus(null);
+      
+        // 如果之前有 DJ 現在沒有，觸發離線動畫
+        if (oldDJStatus) {
+          detectDJStatusChanges(null, oldDJStatus);
+        }
       }
-    } catch (error) {
-      console.warn('Failed to update master device status:', error);
       
-      // 只有在非認證錯誤時才顯示錯誤通知
+      setMasterInfo({
+        isMaster: result.isMaster || false,
+        isLocked: result.isLocked || false,
+        ttl: result.ttl || 0
+      });
+      setCountdown(result.ttl || 0);
+      
+    } catch (error) {
+      console.warn('Failed to update DJ status:', error);
+      
       if (error instanceof Error && !error.message.includes('401')) {
-        console.error('Master device status update failed:', error.message);
+        console.error('DJ status update failed:', error.message);
       }
     }
-  }, [masterDeviceId, deviceId, setMasterInfo, setCountdown]);
+  }, [deviceId, djStatus, setMasterInfo, setCountdown, setDJStatus, detectDJStatusChanges]);
 
   // 定期狀態檢查
   useEffect(() => {
@@ -102,61 +196,124 @@ export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDe
     return () => clearInterval(interval);
   }, [updateMasterDeviceStatus]);
 
-  // 聲明主控裝置所有權
+  // ✨ 透明化升級：聲明 DJ 控制權
   const claimMasterDevice = useCallback(async (): Promise<boolean> => {
     if (!deviceId) return false;
 
     try {
-      const result = await masterDeviceService.current.claimMasterDevice(deviceId);
+      const response = await fetch('/api/spotify/master-device', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId }),
+      });
       
-      setMasterDeviceId(result.masterDeviceId);
-      setMasterInfo(result.state);
-      setCountdown(result.state.ttl);
+      const result = await response.json();
+      
+      if (result.djStatus) {
+        const oldDJStatus = djStatus;
+        
+        setMasterDeviceId(result.djStatus.deviceId);
+        setDJStatus(result.djStatus);
+        setMasterInfo({
+          isMaster: result.isMaster || false,
+          isLocked: result.isLocked || false,
+          ttl: result.ttl || 0
+        });
+        setCountdown(result.ttl || 0);
+        
+        // 檢測並觸發 DJ 轉換動畫
+        detectDJStatusChanges(result.djStatus, oldDJStatus);
       
       // 立即更新其他設備的狀態
       setTimeout(() => updateMasterDeviceStatus(), 500);
       
       return result.success;
-    } catch (error) {
-      console.error('Failed to claim master device:', error);
-      masterDeviceService.current.handleError(error);
-      return false;
-    }
-  }, [deviceId, updateMasterDeviceStatus, setMasterInfo, setCountdown]);
-
-  // 檢查設備是否有執行操作的權限
-  const checkPermissions = useCallback(async (): Promise<boolean> => {
-    try {
-      const result = await masterDeviceService.current.checkDevicePermissions(
-        deviceId,
-        masterDeviceId
-      );
-      
-      // 更新本地狀態
-      if (result.state.ttl > 0) {
-        setMasterInfo(result.state);
-        setCountdown(result.state.ttl);
       }
       
-      return result.hasPermission;
+      return false;
     } catch (error) {
-      console.error('Permission check failed:', error);
-      masterDeviceService.current.handleError(error);
+      console.error('Failed to claim DJ control:', error);
       return false;
     }
-  }, [deviceId, masterDeviceId, setMasterInfo, setCountdown]);
+  }, [deviceId, djStatus, updateMasterDeviceStatus, setMasterInfo, setCountdown, setDJStatus, detectDJStatusChanges]);
 
-  // ✨ 方案 B：閒置重置制功能
+  // ✨ 透明化升級：檢查 DJ 權限
+  const checkPermissions = useCallback(async (): Promise<boolean> => {
+    if (!deviceId) return false;
+    
+    try {
+      const response = await fetch(`/api/spotify/master-device?deviceId=${deviceId}`);
+      const result = await response.json();
+      
+      // 更新本地狀態
+      if (result.ttl > 0) {
+        setMasterInfo({
+          isMaster: result.isMaster || false,
+          isLocked: result.isLocked || false,
+          ttl: result.ttl || 0
+        });
+        setCountdown(result.ttl || 0);
+      }
+      
+      // 如果有 DJ 狀態，檢測變化
+      if (result.djStatus) {
+        const oldDJStatus = djStatus;
+        setDJStatus(result.djStatus);
+        detectDJStatusChanges(result.djStatus, oldDJStatus);
+      }
+      
+      return result.isMaster || !result.isLocked;
+    } catch (error) {
+      console.error('Permission check failed:', error);
+      return false;
+    }
+  }, [deviceId, djStatus, setMasterInfo, setCountdown, setDJStatus, detectDJStatusChanges]);
+
+  // ✨ 透明化升級：閒置重置制功能
   const createIdleResetAction = useCallback(<T extends any[]>(
     action: (...args: T) => Promise<void>,
     actionName?: string
   ) => {
-    return masterDeviceService.current.createIdleResetAction(
-      action,
-      deviceId,
-      actionName || 'User Action'
-    );
-  }, [deviceId]);
+    return async (...args: T) => {
+      try {
+        // 執行原始操作
+        await action(...args);
+        
+        // 如果操作成功且有 deviceId，重置 TTL 並記錄操作詳情
+        if (deviceId) {
+          try {
+            const response = await fetch('/api/spotify/master-device', {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ 
+                deviceId, 
+                actionType: actionName?.toUpperCase().replace(/\s+/g, '_') || 'USER_ACTION',
+                actionDetails: actionName || '用戶操作'
+              }),
+            });
+            
+            const result = await response.json();
+            
+            if (result.success && result.djStatus) {
+              const oldDJStatus = djStatus;
+              setDJStatus(result.djStatus);
+              setCountdown(result.ttl || 0);
+              
+              // 檢測並觸發 TTL 重置動畫
+              detectDJStatusChanges(result.djStatus, oldDJStatus);
+              
+              console.log(`✨ TTL 重置成功: ${actionName}`);
+            }
+          } catch (resetError) {
+            console.warn(`⚠️ TTL 重置失敗: ${actionName}`, resetError);
+          }
+        }
+      } catch (error) {
+        console.error(`❌ 操作失敗: ${actionName}`, error);
+        throw error;
+      }
+    };
+  }, [deviceId, djStatus, setDJStatus, setCountdown, detectDJStatusChanges]);
 
   return {
     masterDeviceId,
@@ -166,5 +323,7 @@ export function useMasterDevice({ deviceId }: UseMasterDeviceProps): UseMasterDe
     checkPermissions,
     updateMasterDeviceStatus,
     createIdleResetAction,
+    currentDJ: djStatus,
+    djName: djStatus?.ownerName || null,
   };
 } 

--- a/src/hooks/usePlaybackControl.ts
+++ b/src/hooks/usePlaybackControl.ts
@@ -186,8 +186,8 @@ export function usePlaybackControl({
     }
   }, 'Start Playback'), "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, player, playPlaylist, defaultPlaylistId, createIdleResetAction]);
 
-  // Play specific track
-  const playTrack = useCallback(createPermissionCheckedAction(async (track: TrackInfo, isInterrupt = false) => {
+  // ✨ Play specific track - 帶有閒置重置制
+  const playTrack = useCallback(createPermissionCheckedAction(createIdleResetAction(async (track: TrackInfo, isInterrupt = false) => {
     // Try to claim master device if no master exists
     const hasClaimed = await claimMasterDeviceWithRetry();
     if (!hasClaimed) return;
@@ -205,7 +205,7 @@ export function usePlaybackControl({
     }
     
     hasPlaybackInitiatedRef.current = true;
-  }, "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, insertTrack, deviceId]);
+  }, 'Track Playback'), "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, insertTrack, deviceId, createIdleResetAction]);
 
   // ✨ Random playback - 帶有閒置重置制
   const handlePlayRandom = useCallback(createPermissionCheckedAction(createIdleResetAction(async () => {

--- a/src/hooks/usePlaybackControl.ts
+++ b/src/hooks/usePlaybackControl.ts
@@ -12,6 +12,10 @@ interface UsePlaybackControlProps {
   defaultPlaylistId: string;
   hasPermissions: () => Promise<boolean>;
   claimMasterDevice: () => Promise<boolean>;
+  createIdleResetAction: <T extends any[]>(
+    action: (...args: T) => Promise<void>,
+    actionName?: string
+  ) => (...args: T) => Promise<void>;
 }
 
 interface UsePlaybackControlReturn {
@@ -33,6 +37,7 @@ export function usePlaybackControl({
   defaultPlaylistId,
   hasPermissions,
   claimMasterDevice,
+  createIdleResetAction,
 }: UsePlaybackControlProps): UsePlaybackControlReturn {
   
   const { 
@@ -117,8 +122,8 @@ export function usePlaybackControl({
     }
   }, [deviceId]);
 
-  // Resume playback
-  const resumeTrack = useCallback(async () => {
+  // ✨ Resume playback - 帶有閒置重置制
+  const resumeTrack = useCallback(createIdleResetAction(async () => {
     if (!player) return;
     
     try {
@@ -126,7 +131,7 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to resume playback:', error);
     }
-  }, [player]);
+  }, 'Resume Playback'), [player, createIdleResetAction]);
 
   // Enhanced master device claiming with retry and smart checking
   const claimMasterDeviceWithRetry = useCallback(async (maxRetries = 2): Promise<boolean> => {
@@ -160,19 +165,26 @@ export function usePlaybackControl({
     return false;
   }, [claimMasterDevice]);
 
-  // Main play function
-  const handlePlay = useCallback(createPermissionCheckedAction(async () => {
+  // ✨ Main play function - 帶有閒置重置制
+  const handlePlay = useCallback(createPermissionCheckedAction(createIdleResetAction(async () => {
     // Try to claim master device if no master exists
     const hasClaimed = await claimMasterDeviceWithRetry();
     if (!hasClaimed) return;
 
     if (hasPlaybackInitiatedRef.current) {
-      await resumeTrack();
+      // 注意：這裡不再調用 resumeTrack，因為它已經有自己的 TTL 重置
+      // 直接調用原始的 resume 邏輯
+      if (!player) return;
+      try {
+        await player.resume();
+      } catch (error) {
+        console.error('Failed to resume playback:', error);
+      }
     } else {
       await playPlaylist(defaultPlaylistId);
       hasPlaybackInitiatedRef.current = true;
     }
-  }, "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, resumeTrack, playPlaylist, defaultPlaylistId]);
+  }, 'Start Playback'), "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, player, playPlaylist, defaultPlaylistId, createIdleResetAction]);
 
   // Play specific track
   const playTrack = useCallback(createPermissionCheckedAction(async (track: TrackInfo, isInterrupt = false) => {
@@ -195,8 +207,8 @@ export function usePlaybackControl({
     hasPlaybackInitiatedRef.current = true;
   }, "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, insertTrack, deviceId]);
 
-  // Random playback
-  const handlePlayRandom = useCallback(createPermissionCheckedAction(async () => {
+  // ✨ Random playback - 帶有閒置重置制
+  const handlePlayRandom = useCallback(createPermissionCheckedAction(createIdleResetAction(async () => {
     // Try to claim master device if no master exists
     const hasClaimed = await claimMasterDeviceWithRetry();
     if (!hasClaimed) return;
@@ -217,10 +229,10 @@ export function usePlaybackControl({
     hasPlaybackInitiatedRef.current = true;
     
     showHtmlToast("已開始隨機播放！");
-  }, "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, get, setQueue, setTrack, setIsPlaying, playPlaylist, defaultPlaylistId]);
+  }, 'Random Playback'), "目前由其他裝置控制中，無法播放。"), [claimMasterDeviceWithRetry, get, setQueue, setTrack, setIsPlaying, playPlaylist, defaultPlaylistId, createIdleResetAction]);
 
-  // Pause playback
-  const pauseTrack = useCallback(createThrottledAction(createPermissionCheckedAction(async () => {
+  // ✨ Pause playback - 帶有閒置重置制
+  const pauseTrack = useCallback(createThrottledAction(createPermissionCheckedAction(createIdleResetAction(async () => {
     if (!player) return;
     
     try {
@@ -228,10 +240,10 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to pause track:', error);
     }
-  }, "目前由其他裝置控制中，無法暫停播放。"), 300), [player, createPermissionCheckedAction]);
+  }, 'Pause Playback'), "目前由其他裝置控制中，無法暫停播放。"), 300), [player, createPermissionCheckedAction, createIdleResetAction]);
 
-  // Next track
-  const nextTrack = useCallback(createThrottledAction(createPermissionCheckedAction(async () => {
+  // ✨ Next track - 帶有閒置重置制
+  const nextTrack = useCallback(createThrottledAction(createPermissionCheckedAction(createIdleResetAction(async () => {
     if (!player) return;
     
     try {
@@ -239,10 +251,10 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to go to next track:', error);
     }
-  }, "目前由其他裝置控制中，無法切換歌曲。")), [player, createPermissionCheckedAction]);
+  }, 'Next Track'), "目前由其他裝置控制中，無法切換歌曲。")), [player, createPermissionCheckedAction, createIdleResetAction]);
 
-  // Previous track
-  const previousTrack = useCallback(createThrottledAction(createPermissionCheckedAction(async () => {
+  // ✨ Previous track - 帶有閒置重置制
+  const previousTrack = useCallback(createThrottledAction(createPermissionCheckedAction(createIdleResetAction(async () => {
     if (!player) return;
     
     try {
@@ -250,10 +262,10 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to go to previous track:', error);
     }
-  }, "目前由其他裝置控制中，無法切換歌曲。")), [player, createPermissionCheckedAction]);
+  }, 'Previous Track'), "目前由其他裝置控制中，無法切換歌曲。")), [player, createPermissionCheckedAction, createIdleResetAction]);
 
-  // Volume control
-  const handleSetVolume = useCallback(async (newVolume: number) => {
+  // ✨ Volume control - 帶有閒置重置制
+  const handleSetVolume = useCallback(createIdleResetAction(async (newVolume: number) => {
     if (!player) return;
     
     try {
@@ -262,10 +274,10 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to set volume:', error);
     }
-  }, [player, setVolumeState]);
+  }, 'Volume Control'), [player, setVolumeState, createIdleResetAction]);
 
-  // Seek position
-  const seek = useCallback(async (newPosition: number) => {
+  // ✨ Seek position - 帶有閒置重置制
+  const seek = useCallback(createIdleResetAction(async (newPosition: number) => {
     if (!player) return;
     
     try {
@@ -274,7 +286,7 @@ export function usePlaybackControl({
     } catch (error) {
       console.error('Failed to seek:', error);
     }
-  }, [player, setProgress]);
+  }, 'Seek Position'), [player, setProgress, createIdleResetAction]);
 
   return {
     playTrack: createThrottledAction(playTrack),

--- a/src/lib/spotify/masterDeviceNotificationHandler.ts
+++ b/src/lib/spotify/masterDeviceNotificationHandler.ts
@@ -55,13 +55,14 @@ export class MasterDeviceNotificationHandler {
 
   /**
    * 處理主控裝置過期的通知
+   * ✨ 已優化為適配閒置重置制的通知邏輯
    */
   private handleMasterDeviceExpired(wasMaster: boolean, deviceId: string | null): void {
     if (!this.notificationState.hasShownExpired) {
       if (wasMaster) {
-        showHtmlToast("您的播放控制權已釋放！");
+        showHtmlToast("您的播放控制權已因閒置而釋放！");
       } else {
-        showHtmlToast("主控裝置已過期，現在可以播放了！");
+        showHtmlToast("主控裝置已閒置過期，現在可以播放了！");
       }
       this.notificationState.hasShownExpired = true;
       this.notificationState.hasShownLocked = false;

--- a/src/lib/spotify/masterDeviceNotificationHandler.ts
+++ b/src/lib/spotify/masterDeviceNotificationHandler.ts
@@ -1,17 +1,23 @@
 import { showHtmlToast } from '@/lib/notify';
-import { NotificationState } from '@/types/spotify';
+import { NotificationState, DJStatus } from '@/types/spotify';
 
-export interface MasterDeviceNotificationContext {
+// ✨ 透明化升級：豐富的通知上下文
+export interface TransparentMasterDeviceNotificationContext {
   wasMaster: boolean;
   isNowMaster: boolean;
   isNowLocked: boolean;
   deviceId: string | null;
   masterDeviceId: string | null;
+  // ✨ 新增的透明化信息
+  djStatus: DJStatus | null;
+  previousDJStatus: DJStatus | null;
+  transitionType?: 'CLAIMED' | 'RELEASED' | 'EXPIRED' | 'TTL_RESET';
+  actionDetails?: string;
 }
 
 /**
- * 主控裝置通知處理器
- * 負責管理和顯示與主控裝置狀態相關的通知
+ * ✨ 透明化升級：主控裝置通知處理器
+ * 負責管理和顯示與透明化 DJ 狀態相關的豐富通知
  */
 export class MasterDeviceNotificationHandler {
   private notificationState: NotificationState = {
@@ -30,39 +36,81 @@ export class MasterDeviceNotificationHandler {
   }
 
   /**
-   * 處理主控裝置狀態變化的通知
+   * ✨ 透明化升級：處理主控裝置狀態變化的豐富通知
    */
-  handleMasterDeviceStatusChange(context: MasterDeviceNotificationContext): void {
-    const { wasMaster, isNowMaster, isNowLocked, deviceId, masterDeviceId } = context;
+  handleMasterDeviceStatusChange(context: TransparentMasterDeviceNotificationContext): void {
+    const { 
+      wasMaster, 
+      isNowMaster, 
+      isNowLocked, 
+      deviceId, 
+      masterDeviceId,
+      djStatus,
+      previousDJStatus,
+      transitionType 
+    } = context;
+
+    // ✨ 處理 TTL 重置通知
+    if (transitionType === 'TTL_RESET' && djStatus) {
+      this.handleTTLResetNotification(djStatus);
+      return;
+    }
 
     // 如果沒有主控裝置（已過期）
     if (!masterDeviceId) {
-      this.handleMasterDeviceExpired(wasMaster, deviceId);
+      this.handleMasterDeviceExpired(wasMaster, deviceId, previousDJStatus);
       return;
     }
 
     // 如果現在被鎖定
     if (isNowLocked) {
-      this.handleDeviceLocked();
+      this.handleDeviceLocked(djStatus);
       return;
     }
 
     // 如果成為主控裝置
     if (isNowMaster) {
-      this.handleBecameMaster();
+      this.handleBecameMaster(djStatus);
     }
   }
 
   /**
-   * 處理主控裝置過期的通知
-   * ✨ 已優化為適配閒置重置制的通知邏輯
+   * ✨ 透明化升級：處理 TTL 重置通知
    */
-  private handleMasterDeviceExpired(wasMaster: boolean, deviceId: string | null): void {
+  private handleTTLResetNotification(djStatus: DJStatus): void {
+    const actionType = djStatus.lastAction?.type || 'USER_ACTION';
+    const actionName = this.getActionDisplayName(actionType);
+    
+    // 只在非當前用戶的重置時顯示通知，避免干擾自己的操作
+    if (djStatus.ownerName !== '您') {
+      showHtmlToast(
+        `🎵 ${djStatus.ownerName} 進行了 ${actionName}，播放權延長 2 分鐘`, 
+        { type: 'info' }
+      );
+    }
+  }
+
+  /**
+   * ✨ 透明化升級：處理主控裝置過期的通知
+   */
+  private handleMasterDeviceExpired(
+    wasMaster: boolean, 
+    deviceId: string | null, 
+    previousDJStatus: DJStatus | null
+  ): void {
     if (!this.notificationState.hasShownExpired) {
       if (wasMaster) {
-        showHtmlToast("您的播放控制權已因閒置而釋放！");
+        showHtmlToast("🎭 您的 DJ 控制權已因閒置而釋放！");
       } else {
-        showHtmlToast("主控裝置已閒置過期，現在可以播放了！");
+        const previousDJName = previousDJStatus?.ownerName || '前任 DJ';
+        const sessionDuration = previousDJStatus 
+          ? Math.floor((Date.now() - previousDJStatus.sessionStartAt) / 60000)
+          : 0;
+        
+        showHtmlToast(
+          `🎉 ${previousDJName} 已離開 DJ 台（時長 ${sessionDuration} 分鐘），現在開放搶奪主控權！`,
+          { type: 'success' }
+        );
       }
       this.notificationState.hasShownExpired = true;
       this.notificationState.hasShownLocked = false;
@@ -70,61 +118,143 @@ export class MasterDeviceNotificationHandler {
   }
 
   /**
-   * 處理裝置被鎖定的通知
+   * ✨ 透明化升級：處理裝置被鎖定的通知
    */
-  private handleDeviceLocked(): void {
+  private handleDeviceLocked(djStatus: DJStatus | null): void {
     if (!this.notificationState.hasShownLocked) {
-      showHtmlToast("目前由其他裝置控制中，無法播放。", { type: 'error' });
+      const djName = djStatus?.ownerName || '其他用戶';
+      const lastAction = djStatus?.lastAction?.details || '未知操作';
+      const actionCount = djStatus?.actionCount || 0;
+      
+      showHtmlToast(
+        `🔒 ${djName} 正在控制播放器 (已操作 ${actionCount} 次，最後: ${lastAction})`,
+        { type: 'error' }
+      );
       this.notificationState.hasShownLocked = true;
       this.notificationState.hasShownExpired = false;
     }
   }
 
   /**
-   * 處理成為主控裝置的狀態
+   * ✨ 透明化升級：處理成為主控裝置的狀態
    */
-  private handleBecameMaster(): void {
+  private handleBecameMaster(djStatus: DJStatus | null): void {
     this.notificationState.hasShownLocked = false;
     this.notificationState.hasShownExpired = false;
-  }
-
-  /**
-   * 顯示成功取得主控權的通知
-   */
-  showClaimSuccessNotification(): void {
-    showHtmlToast("已取得播放主控權！點按播放鍵開始播放");
-    this.resetNotificationState();
-  }
-
-  /**
-   * 顯示取得主控權失敗的通知
-   */
-  showClaimFailedNotification(): void {
-    showHtmlToast("哎呀！就在您點擊的瞬間，其他人搶先一步了！");
-  }
-
-  /**
-   * 顯示自動重新取得主控權的通知
-   */
-  showAutoReclaimSuccessNotification(): void {
-    showHtmlToast('已自動重新取得播放主控權！', { type: 'success' });
-  }
-
-  /**
-   * 顯示錯誤通知
-   */
-  showErrorNotification(error: Error): void {
-    if (error.message.includes('401') || error.message.includes('Authentication expired')) {
-      showHtmlToast("Spotify 認證已過期，請重新整理頁面", { type: 'error' });
-    } else {
-      showHtmlToast(`操作失敗: ${error.message}`, { type: 'error' });
+    
+    if (djStatus) {
+      const sessionTime = new Date(djStatus.sessionStartAt).toLocaleTimeString();
+      showHtmlToast(
+        `👑 歡迎，DJ ${djStatus.ownerName}！您的控制開始於 ${sessionTime}`,
+        { type: 'success' }
+      );
     }
   }
 
   /**
-   * 顯示通用錯誤通知
+   * ✨ 透明化升級：顯示成功取得主控權的通知
    */
-  showGenericErrorNotification(message: string): void {
-    showHtmlToast(message, { type: 'error' });
+  showClaimSuccessNotification(djStatus?: DJStatus): void {
+    if (djStatus) {
+      showHtmlToast(
+        `🎉 已成為 DJ ${djStatus.ownerName}！點按播放鍵開始您的音樂控制`,
+        { type: 'success' }
+      );
+    } else {
+      showHtmlToast("已取得播放主控權！點按播放鍵開始播放");
+    }
+    this.resetNotificationState();
+  }
+
+  /**
+   * ✨ 透明化升級：顯示取得主控權失敗的通知
+   */
+  showClaimFailedNotification(currentDJ?: DJStatus): void {
+    if (currentDJ) {
+      showHtmlToast(
+        `😅 ${currentDJ.ownerName} 搶先一步了！(已操作 ${currentDJ.actionCount} 次)`,
+        { type: 'warning' }
+      );
+    } else {
+      showHtmlToast("哎呀！就在您點擊的瞬間，其他人搶先一步了！");
+    }
+  }
+
+  /**
+   * ✨ 透明化升級：顯示自動重新取得主控權的通知
+   */
+  showAutoReclaimSuccessNotification(djStatus?: DJStatus): void {
+    if (djStatus) {
+      showHtmlToast(
+        `🔄 已自動重新成為 DJ ${djStatus.ownerName}！歡迎回到 DJ 台`,
+        { type: 'success' }
+      );
+    } else {
+      showHtmlToast('已自動重新取得播放主控權！', { type: 'success' });
+    }
+  }
+
+  /**
+   * ✨ 工具方法：將操作類型轉換為用戶友善的顯示名稱
+   */
+  private getActionDisplayName(actionType: string): string {
+    const actionMap: Record<string, string> = {
+      'PLAY': '播放',
+      'PAUSE': '暫停',
+      'NEXT_TRACK': '下一首',
+      'PREVIOUS_TRACK': '上一首',
+      'VOLUME_CHANGE': '調整音量',
+      'SEEK': '拖拽進度',
+      'PLAY_RANDOM': '隨機播放',
+      'TRACK_SELECT': '選擇歌曲',
+      'CONTROL_CLAIM': '取得控制權',
+      'CONTROL_REFRESH': '刷新控制權',
+      'USER_ACTION': '用戶操作',
+    };
+    
+    return actionMap[actionType] || '未知操作';
+  }
+
+  /**
+   * ✨ 透明化升級：顯示錯誤通知
+   */
+  showErrorNotification(error: Error, djStatus?: DJStatus): void {
+    if (error.message.includes('401') || error.message.includes('Authentication expired')) {
+      showHtmlToast("🔑 Spotify 認證已過期，請重新整理頁面", { type: 'error' });
+    } else {
+      const context = djStatus ? ` (當前 DJ: ${djStatus.ownerName})` : '';
+      showHtmlToast(`❌ 操作失敗: ${error.message}${context}`, { type: 'error' });
+    }
+  }
+
+  /**
+   * ✨ 透明化升級：顯示通用錯誤通知
+   */
+  showGenericErrorNotification(message: string, djStatus?: DJStatus): void {
+    const context = djStatus ? ` (當前 DJ: ${djStatus.ownerName})` : '';
+    showHtmlToast(`⚠️ ${message}${context}`, { type: 'error' });
+  }
+
+  /**
+   * ✨ 透明化升級：顯示 DJ 統計通知
+   */
+  showSessionStatsNotification(djStatus: DJStatus): void {
+    const sessionDuration = Math.floor((Date.now() - djStatus.sessionStartAt) / 60000);
+    const avgActionsPerMinute = sessionDuration > 0 ? Math.round(djStatus.actionCount / sessionDuration) : 0;
+    
+    showHtmlToast(
+              `📊 您的 DJ 統計：${djStatus.actionCount} 次操作，${sessionDuration} 分鐘，平均 ${avgActionsPerMinute} 操作/分鐘`,
+      { type: 'info' }
+    );
+  }
+
+  /**
+   * ✨ 透明化升級：顯示 DJ 權限轉移通知
+   */
+  showDJTransferNotification(fromDJ: DJStatus, toDJ: DJStatus): void {
+    showHtmlToast(
+      `🎭 DJ 權限轉移：${fromDJ.ownerName} → ${toDJ.ownerName}`,
+      { type: 'info' }
+    );
   }
 } 

--- a/src/services/spotifyApiService.ts
+++ b/src/services/spotifyApiService.ts
@@ -120,6 +120,18 @@ class SpotifyApiService {
     }, 2);
   }
 
+  /**
+   * ✨ 方案 B：閒置重置制 - 重置主控裝置的 TTL
+   * 在每次有效操作後調用，實現活躍使用者的主控權延續
+   */
+  async resetMasterDeviceTTL(deviceId: string): Promise<MasterDeviceResponse> {
+    return await this.makeApiCall<MasterDeviceResponse>('/api/spotify/master-device', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId }),
+    }, 1); // 重置 TTL 不需要重試太多次
+  }
+
   async getMasterDeviceConfig(): Promise<MasterDeviceConfig> {
     return await this.makeApiCall<MasterDeviceConfig>('/api/spotify/master-device/config', {}, 1);
   }

--- a/src/services/spotifyApiService.ts
+++ b/src/services/spotifyApiService.ts
@@ -1,4 +1,4 @@
-import { NowPlayingResponse, MasterDeviceResponse, MasterDeviceConfig, TrackInfo, PlaybackError } from '@/types/spotify';
+import { NowPlayingResponse, MasterDeviceResponse, MasterDeviceConfig, TrackInfo, PlaybackError, TransparentMasterDeviceResponse } from '@/types/spotify';
 
 class SpotifyApiService {
   // Helper method for making API calls with retry logic
@@ -108,12 +108,12 @@ class SpotifyApiService {
   }
 
   // Master Device Management APIs
-  async getMasterDevice(): Promise<MasterDeviceResponse> {
-    return await this.makeApiCall<MasterDeviceResponse>('/api/spotify/master-device', {}, 2);
+  async getMasterDevice(): Promise<TransparentMasterDeviceResponse> {
+    return await this.makeApiCall<TransparentMasterDeviceResponse>('/api/spotify/master-device', {}, 2);
   }
 
-  async claimMasterDevice(deviceId: string): Promise<MasterDeviceResponse> {
-    return await this.makeApiCall<MasterDeviceResponse>('/api/spotify/master-device', {
+  async claimMasterDevice(deviceId: string): Promise<TransparentMasterDeviceResponse> {
+    return await this.makeApiCall<TransparentMasterDeviceResponse>('/api/spotify/master-device', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ deviceId }),
@@ -121,14 +121,22 @@ class SpotifyApiService {
   }
 
   /**
-   * ✨ 方案 B：閒置重置制 - 重置主控裝置的 TTL
-   * 在每次有效操作後調用，實現活躍使用者的主控權延續
+   * ✨ 透明化升級：重置 DJ 狀態的 TTL
+   * 現在支援傳遞操作類型和詳情，實現完全透明的狀態管理
    */
-  async resetMasterDeviceTTL(deviceId: string): Promise<MasterDeviceResponse> {
-    return await this.makeApiCall<MasterDeviceResponse>('/api/spotify/master-device', {
+  async resetMasterDeviceTTL(
+    deviceId: string, 
+    actionType?: string, 
+    actionDetails?: string
+  ): Promise<TransparentMasterDeviceResponse> {
+    return await this.makeApiCall<TransparentMasterDeviceResponse>('/api/spotify/master-device', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ deviceId }),
+      body: JSON.stringify({ 
+        deviceId, 
+        actionType: actionType || 'USER_ACTION',
+        actionDetails: actionDetails || '用戶操作'
+      }),
     }, 1); // 重置 TTL 不需要重試太多次
   }
 

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -108,3 +108,42 @@ export type NotificationState = {
   hasShownLocked: boolean;
   hasShownExpired: boolean;
 }; 
+
+// ✨ 透明化升級：DJ 狀態管理
+export interface DJStatus {
+  deviceId: string;
+  ownerName: string;
+  avatarUrl?: string;
+  lastActionAt: number; // Unix timestamp
+  sessionStartAt: number; // Unix timestamp  
+  actionCount: number; // 操作計數
+  lastAction?: {
+    type: string;
+    timestamp: number;
+    details?: string;
+  };
+}
+
+export interface TransparentMasterDeviceResponse {
+  djStatus: DJStatus | null;
+  ttl: number;
+  success?: boolean;
+  currentMasterId?: string;
+  isLocked: boolean;
+  isMaster: boolean;
+}
+
+export interface TTLResetEvent {
+  newTTL: number;
+  resetBy: string; // DJ name
+  actionType: string;
+  timestamp: number;
+}
+
+export interface DJSessionTransition {
+  type: 'CLAIMED' | 'RELEASED' | 'EXPIRED' | 'TRANSFERRED';
+  previousDJ?: string;
+  newDJ?: string;
+  timestamp: number;
+  reason: string;
+} 


### PR DESCRIPTION


## **一、功能概述 (Summary)**

這個 PR 完整地實現並優化了共享音樂電台的「主控權管理」系統，將其從一個單純的播放器升級為一個**富有遊戲化、社交感和狀態透明化的「共享 DJ 體驗」**。

核心是引入了**方案 B：閒置重置制**，並在此基礎上，圍繞「**遊戲化 DJ 控場**」的原則進行了全面的 UI 和 UX 升級，確保了活躍 DJ 的體驗流暢性與等待者的資訊透明度。

---

## **二、解決的核心問題 (Resolves)**

1.  **解決「固定時長制」的體驗斷點**：徹底拋棄了僵硬的固定時長方案，活躍的 DJ 在操作時，其控制權將**永遠不會被中斷**。
2.  **解決「等待者」的體驗盲區**：舊機制的倒數計時器重置對等待者來說是個黑盒子。新機制透過**UI 動畫與狀態透明化**，讓等待者能清晰地感知到主控權因何被延長，將困惑轉為有趣的「觀戰」體驗。
3.  **防止惡意佔用**：透過前端的**操作節流 (Throttling)** 與 **30 秒冷卻機制**，有效防止使用者透過高頻率請求來永久霸佔主控權，確保了機制的公平性。
4.  **修復功能覆蓋缺口**：確保了所有播放入口（包括文章頁和關於頁面的主題曲插播）都能正確觸發主控權的 TTL 重置。
5.  **優化行動裝置 UI**：針對手機等小螢幕裝置，對過長的文字（如 DJ 狀態、通知訊息）進行了精簡，提升了在不同裝置上的一致性體驗。

---

## **三、主要實現細節 (Implementation Details)**

**後端 (`/api/spotify/master-device`)**
* **狀態升級**：Vercel KV 中儲存的 `master_device` 不再只是一個 `deviceId`，而是一個包含 `deviceId`, `ownerName`, `actionCount`, `sessionStartAt`, `lastActionAt` 等資訊的完整 **DJ 狀態物件**。
* **原子化操作**：使用 `setnx` 確保在任何時刻只有一位使用者能成功搶佔 DJ 位置。
* **API 擴充**：新增 `PATCH` 方法，專門用於處理來自前端的 TTL 重置與操作計數更新請求。

**前端 Hooks (`useMasterDevice`, `usePlaybackControl`)**
* **閒置重置攔截器 (`createIdleResetAction`)**：建立了一個高階函式，以非侵入性的方式包裹了所有「有效操作」，在功能執行的同時觸發後端 TTL 重置。
* **狀態同步**：`useMasterDevice` 現在會定期從後端獲取完整的 DJ 狀態，並將其同步到 Zustand Store 中。
* **動效觸發**：透過比較前後兩次獲取的 `ttl` 或 `lastActionAt`，精準判斷出計時器是被「操作重置」的，並觸發 UI 動畫。

**UI 元件 (`MusicControlPanel.tsx`)**
* **完全體現設計稿**：UI 現在能精準渲染出當前 DJ 的**隨機代號**、**操作次數**和**控場時長**。
* **情境化顯示**：
    * **主控者視角**：尊榮的皇冠標示與即時更新的個人戰績。
    * **等待者視角**：清晰顯示當前 DJ 代號，並在 TTL 重置時，提供「**+120s**」的視覺回饋，讓狀態變化一目了然。
* **響應式設計**：為行動裝置提供了更簡潔的 UI 文案，確保在小螢幕上的顯示效果。

**通用工具 (`utils.ts`)**
* **DJ 代號生成器**：新增 `generateDjAlias` 函式，用「形容詞 + 名詞 + ID」的組合，為每一位 DJ 生成獨一無二的有趣稱號。

---

## **四、如何測試 (How to Test)**

1.  **主控權搶佔與顯示**：
    * 在無人控制時，點擊「成為派對DJ」。
    * **預期結果**：成功變為主控者，並在 UI 上看到隨機生成的 DJ 代號、操作次數 (1次)、以及開始計時的「控場時長」。
2.  **閒置重置與防濫用**：
    * 獲取主控權後，執行任一有效操作（如下一首）。
    * **預期結果**：「操作次數」+1，倒數計時器**重置為 120 秒**。
    * 在 30 秒內快速連續操作。
    * **預期結果**：功能正常執行，但 TTL 只會被重置一次。
3.  **狀態透明化 (等待者視角)**：
    * 使用裝置 A 取得主控權。
    * 使用裝置 B 進入頁面，此時應為「鎖定模式」。
    * **預期結果**：裝置 B 能看到裝置 A 的 DJ 代號，並顯示「`[DJ代號]` 控制中」。
    * 在裝置 A 上執行操作。
    * **預期結果**：裝置 B 上的倒數計時器數字會觸發一個**短暫的視覺動畫**（如變色、放大），明確表示主控權被延長。
4.  **閒置過期**：
    * 獲取主控權後，閒置 2 分鐘不進行任何操作。
    * **預期結果**：主控權自動釋放，UI 切換回「DJ 台空閒中」的狀態，並彈出對應的過期通知。

---

這個 PR 不僅僅是一次功能新增，更是對產品核心互動體驗的一次深刻打磨與升級。🎉